### PR TITLE
Bump zebra to v2.0.1, pin zcashd for predictable updates

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -4,7 +4,7 @@ zcashd:
   testnet: False
   image:
     repository: electriccoinco/zcashd
-    tag: latest
+    tag: v6.0.0
     pullPolicy: IfNotPresent
   replicas: 1
   reindex: False
@@ -30,7 +30,7 @@ zebra:
   testnet: false
   image:
     repository: zfnd/zebra
-    tag: v1.9.0
+    tag: v2.0.1
     pullPolicy: IfNotPresent
   replicas: 1
   additionalEnv: {}


### PR DESCRIPTION
Here's a quick patch to bring this chart's Zebra version up to date.

Regarding zcashd, it's a Kubernetes best practice to pin container image tags to ensure that replicas run the same versions when scaling, and to make sure that updates actually happen. (the concept of "latest" is not always refreshed)